### PR TITLE
Fixed associated docker hub account for the Command Line example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ http://www.ntop.org/products/traffic-analysis/ntop/
 
 ### Command Line
  ```
-docker run --net=host -t -p 3000:3000 vostronet/ntopng <ntopng arguments>
+docker run --net=host -t -p 3000:3000 vostro/ntopng <ntopng arguments>
  ```


### PR DESCRIPTION
When I tried to run the Command Line example it failed to find the image.  Realized it was simply a typo or un-updated content from an account move.  Updated the image location.

*NOTE:* The image now pulls and container starts, but it can not find a redis server to connect to and stops.